### PR TITLE
Fixed typo - s/wepb/webp/

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 FasterImage finds the dimensions or filetype of a remote image file given its uri by fetching as little as needed, based on the excellent [Ruby implementation by Stephen Sykes](https://github.com/sdsykes/fastimage) and [PHP implementation by Tom Moor](https://github.com/tommoor/fastimage).
 
-FasterImage uses the curl_muli* suite to run requests in parallel. Currently supports JPG, GIF, PNG, WEPB, BMP, PSD, TIFF, and ICO files.
+FasterImage uses the curl_muli* suite to run requests in parallel. Currently supports JPG, GIF, PNG, WEBP, BMP, PSD, TIFF, and ICO files.
 
 ## Usage
 ```php


### PR DESCRIPTION
I'm pretty sure this is a typo, no?

(BTW, thanks for writing this library, we use it ALL the time.) 