### PR TITLE
Limit isRotated to only check for valid orientation values

### DIFF
--- a/src/FasterImage/ExifParser.php
+++ b/src/FasterImage/ExifParser.php
@@ -71,7 +71,7 @@ class ExifParser
      */
     public function isRotated()
     {
-        return (! empty($this->orientation) && $this->orientation >= 5);
+        return (! empty($this->orientation) && $this->orientation >= 5 && $this->orientation <= 8);
     }
 
     /**


### PR DESCRIPTION
We have an image that has an orientation of 49 which isn't even a valid value.  I am not able to give the image because it is a customer's image and I do not have permission to share it.