### PR TITLE
Add ability for user agent, buffer size, and SSL host/peer verification to be overridden

### DIFF
--- a/src/FasterImage/FasterImage.php
+++ b/src/FasterImage/FasterImage.php
@@ -19,11 +19,32 @@ use WillWashburn\Stream\Stream;
 class FasterImage
 {
     /**
-     * The default timeout
+     * The default timeout.
      *
      * @var int
      */
     protected $timeout = 10;
+
+    /**
+     * The default buffer size.
+     *
+     * @var int
+     */
+    protected $bufferSize = 256;
+
+    /**
+     * The default for whether to verify SSL peer.
+     *
+     * @var bool
+     */
+    protected $sslVerifyPeer = false;
+
+    /**
+     * The default for whether to verify SSL host.
+     *
+     * @var bool
+     */
+    protected $sslVerifyHost = false;
 
     /**
      * If the content length should be included in the result set.
@@ -33,7 +54,7 @@ class FasterImage
     protected $includeContentLength = false;
 
     /**
-     * The user agent to set for requests.
+     * The default user agent to set for requests.
      *
      * @var string
      */
@@ -102,6 +123,30 @@ class FasterImage
     }
 
     /**
+     * @param int $bufferSize
+     */
+    public function setBufferSize($bufferSize)
+    {
+        $this->bufferSize = (int) $bufferSize;
+    }
+
+    /**
+     * @param bool $sslVerifyPeer
+     */
+    public function setSslVerifyPeer($sslVerifyPeer)
+    {
+        $this->sslVerifyPeer = (bool) $sslVerifyPeer;
+    }
+
+    /**
+     * @param bool $sslVerifyHost
+     */
+    public function setSslVerifyHost($sslVerifyHost)
+    {
+        $this->sslVerifyHost = (bool) $sslVerifyHost;
+    }
+
+    /**
      * @param bool $bool
      */
     public function setIncludeContentLength($bool)
@@ -137,9 +182,9 @@ class FasterImage
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_HEADER, 0);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($ch, CURLOPT_BUFFERSIZE, 256);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+        curl_setopt($ch, CURLOPT_BUFFERSIZE, $this->bufferSize);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->sslVerifyPeer ? 1 : 0);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, $this->sslVerifyHost ? 2 : 0);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->timeout);
         curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);

--- a/src/FasterImage/FasterImage.php
+++ b/src/FasterImage/FasterImage.php
@@ -33,6 +33,25 @@ class FasterImage
     protected $includeContentLength = false;
 
     /**
+     * The user agent to set for requests.
+     *
+     * @var string
+     */
+    protected $userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.110 Safari/537.36';
+
+    /**
+     * Constructor.
+     *
+     * @param string $userAgent Optional. User agent to set for requests.
+     */
+    public function __construct($userAgent = '')
+    {
+        if ( ! empty( $userAgent ) ) {
+            $this->userAgent = $userAgent;
+        }
+    }
+
+    /**
      * Get the size of each of the urls in a list
      *
      * @param array $urls
@@ -130,7 +149,7 @@ class FasterImage
         curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
 
         #  Some web servers require the useragent to be not a bot. So we are liars.
-        curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.110 Safari/537.36');
+        curl_setopt($ch, CURLOPT_USERAGENT, $this->userAgent);
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
             "Accept: image/webp,image/*,*/*;q=0.8",
             "Cache-Control: max-age=0",

--- a/src/FasterImage/FasterImage.php
+++ b/src/FasterImage/FasterImage.php
@@ -40,18 +40,6 @@ class FasterImage
     protected $userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.110 Safari/537.36';
 
     /**
-     * Constructor.
-     *
-     * @param string $userAgent Optional. User agent to set for requests.
-     */
-    public function __construct($userAgent = '')
-    {
-        if ( ! empty( $userAgent ) ) {
-            $this->userAgent = $userAgent;
-        }
-    }
-
-    /**
      * Get the size of each of the urls in a list
      *
      * @param array $urls
@@ -106,19 +94,27 @@ class FasterImage
     }
 
     /**
-     * @param $seconds
+     * @param int $seconds
      */
     public function setTimeout($seconds)
     {
-        $this->timeout = $seconds;
+        $this->timeout = (int) $seconds;
     }
 
     /**
-     * @param $bool
+     * @param bool $bool
      */
     public function setIncludeContentLength($bool)
     {
         $this->includeContentLength = (bool) $bool;
+    }
+
+    /**
+     * @param string $userAgent
+     */
+    public function setUserAgent($userAgent)
+    {
+        $this->userAgent = $userAgent;
     }
 
     /**


### PR DESCRIPTION
In the [AMP plugin for WordPress](https://github.com/ampproject/amp-wp), the user agent, buffer size, and SSL host/peer verification are overridden. 

The user agent is overridden to indicate the actual source as opposed to emulating Chrome:

https://github.com/ampproject/amp-wp/blob/158855dc3349e1e18099dba959ab49dedf806ff6/includes/utils/class-amp-image-dimension-extractor.php#L216-L217

(Disregard the `@todo` comment as we have implemented in a [patch](https://github.com/ampproject/amp-wp/blob/4228eee8332c109eff62df5dba0ae4d7c4137ef2/patches/fasterimage-fixes.diff#L9-L47) we apply.)

This PR applies the patch to `fasterimage` itself so that it can be passed  via a new `setUserAgent()` setter method.

Similarly, the AMP plugin is patching the buffer size, SSL peer verification, and SSL host verification:

https://github.com/ampproject/amp-wp/blob/4228eee8332c109eff62df5dba0ae4d7c4137ef2/patches/fasterimage-fixes.diff#L35-L40

By class member variables and setter methods, patching in this way will no longer be required.