### PR TITLE
Add support for parsing dimensions from SVG images

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[{*.json,*.yml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/src/FasterImage/ImageParser.php
+++ b/src/FasterImage/ImageParser.php
@@ -366,7 +366,7 @@ class ImageParser
     {
         $this->stream->resetPointer();
 
-        // Keep reading bytes until
+        // Keep reading bytes until we find the complete <svg> start tag.
         $inside = false;
         $markup = '';
         while ( true ) {

--- a/tests/FasterImageTest.php
+++ b/tests/FasterImageTest.php
@@ -34,10 +34,6 @@ class FasterImageTest extends PHPUnit_Framework_TestCase
     {
         $data = $this->linksProvider();
 
-        // Only do one of the batch tests to avoid timeouts in travis
-        // feel free to test this locally without it
-        $data = array_slice($data, 0, 1);
-
         $expected = [];
         $uris     = [];
 

--- a/tests/FasterImageTest.php
+++ b/tests/FasterImageTest.php
@@ -34,11 +34,6 @@ class FasterImageTest extends PHPUnit_Framework_TestCase
     {
         $data = $this->linksProvider();
 
-        // Only do one of the batch tests to avoid timeouts in travis for PHP<7.0 since too slow.
-        if ( version_compare( PHP_VERSION, '7.0', '<' ) ) {
-            $data = array_slice($data, 0, 1);
-        }
-
         $expected = [];
         $uris     = [];
 

--- a/tests/FasterImageTest.php
+++ b/tests/FasterImageTest.php
@@ -34,6 +34,12 @@ class FasterImageTest extends PHPUnit_Framework_TestCase
     {
         $data = $this->linksProvider();
 
+        // Only do one of the batch tests to avoid timeouts in travis
+        // feel free to test this locally without it
+        if ( isset( $_ENV['TRAVIS'] ) ) {
+            $data = array_slice($data, 0, 1);
+        }
+
         $expected = [];
         $uris     = [];
 

--- a/tests/FasterImageTest.php
+++ b/tests/FasterImageTest.php
@@ -91,6 +91,7 @@ class FasterImageTest extends PHPUnit_Framework_TestCase
             ['https://s.w.org/images/core/emoji/11/svg/1f642.svg', 36, 36, 'svg'], // With viewBox only.
             ['https://gist.github.com/westonruter/0d66e6629526fc820a31fd43cf325376/raw/ed26b6d60b3d1c07a82907553795e6535c12da89/smiley-oval-vertical-padding.svg', 36, 96, 'svg'],
             ['https://gist.github.com/westonruter/0d66e6629526fc820a31fd43cf325376/raw/4c3b8d7fdad3233d669c05c7313c0503c8a3c8ed/smiley-with-dimensions-and-offcenter-viewbox.svg', 36, 42, 'svg'],
+            ['https://gist.github.com/westonruter/0d66e6629526fc820a31fd43cf325376/raw/23651d8fec1a22707632f687b742700896daf54f/svg-tag-commented-out.svg', 38, 44, 'svg'],
         );
     }
 }

--- a/tests/FasterImageTest.php
+++ b/tests/FasterImageTest.php
@@ -34,9 +34,8 @@ class FasterImageTest extends PHPUnit_Framework_TestCase
     {
         $data = $this->linksProvider();
 
-        // Only do one of the batch tests to avoid timeouts in travis
-        // feel free to test this locally without it
-        if ( isset( $_ENV['TRAVIS'] ) ) {
+        // Only do one of the batch tests to avoid timeouts in travis for PHP<7.0 since too slow.
+        if ( version_compare( PHP_VERSION, '7.0', '<' ) ) {
             $data = array_slice($data, 0, 1);
         }
 

--- a/tests/FasterImageTest.php
+++ b/tests/FasterImageTest.php
@@ -92,6 +92,9 @@ class FasterImageTest extends PHPUnit_Framework_TestCase
             ['https://github.com/sdsykes/fastimage/raw/master/test/fixtures/webp_vp8x.webp', 386, 395, 'webp'],
             ['http://ketosizeme.com/wp-content/uploads/2016/11/Keto-Corn-Dog-Recipe-Low-Carb-High-Fat-.jpg', 700, 467, 'jpeg'],
             ['http://gluesticksgumdrops.com/wp-content/uploads/2015/03/how-to-find-more-time-to-read-to-your-kids.jpg', 700, 1000, 'jpeg'],
+            ['https://s.w.org/images/core/emoji/11/svg/1f642.svg', 36, 36, 'svg'], // With viewBox only.
+            ['https://gist.github.com/westonruter/0d66e6629526fc820a31fd43cf325376/raw/ed26b6d60b3d1c07a82907553795e6535c12da89/smiley-oval-vertical-padding.svg', 36, 96, 'svg'],
+            ['https://gist.github.com/westonruter/0d66e6629526fc820a31fd43cf325376/raw/4c3b8d7fdad3233d669c05c7313c0503c8a3c8ed/smiley-with-dimensions-and-offcenter-viewbox.svg', 36, 42, 'svg'],
         );
     }
 }


### PR DESCRIPTION
The [AMP plugin for WordPress](https://github.com/ampproject/amp-wp) patches FasterImage to add support for extracting dimension information from SVG images:

https://github.com/ampproject/amp-wp/blob/4228eee8332c109eff62df5dba0ae4d7c4137ef2/patches/fasterimage-fixes.diff#L51-L115

It is admittedly somewhat non-sensical to obtain dimensions from SVGs since they are vector images. Nevertheless, when there is an [SVG image](https://gist.github.com/westonruter/0d66e6629526fc820a31fd43cf325376) like:

```xml
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" width="36" height="36"><circle fill="#FFCC4D" cx="18" cy="18" r="18"/><path fill="#664500" d="M10.515 23.621C10.56 23.8 11.683 28 18 28c6.318 0 7.44-4.2 7.485-4.379.055-.217-.043-.442-.237-.554-.195-.111-.439-.078-.6.077C24.629 23.163 22.694 25 18 25s-6.63-1.837-6.648-1.855C11.256 23.05 11.128 23 11 23c-.084 0-.169.021-.246.064-.196.112-.294.339-.239.557z"/><ellipse fill="#664500" cx="12" cy="13.5" rx="2.5" ry="3.5"/><ellipse fill="#664500" cx="24" cy="13.5" rx="2.5" ry="3.5"/></svg>
```

And it is added to a page without `width` or `height` attributes:

```html
<img src="http://wordpressdev.lndo.site/content/uploads/smiley.svg">
```

It will get rendered with those dimensions defined in the SVG file:

> ![image](https://user-images.githubusercontent.com/134745/53915729-59682880-4015-11e9-99b0-38dad3e2f289.png)

The FasterImage library is used in the AMP plugin to supply `width` and `height` attributes for any `img` that lacks it in the HTML document. By supplying the dimensions, a better user experience results by avoiding content shifting as images are loaded into the page. (This is why AMP requires the dimensions.) Including support for SVG helps to this end.

Note that this PR not only extracts the `width` and `height` attributes from the SVG image, but it also falls back to inferring (i.e. guessing) a width/height from the SVG [`viewBox`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox).

~⚠️  There are two outstanding issues with this PR, however, and that has to do with SVG images that are extremely small. It turns out that the [Stream](https://github.com/willwashburn/stream) library doesn't like handling SVG images that are smaller than 1024 bytes. I took a shot at working on a patch in https://github.com/ampproject/amp-wp/pull/1807/files but you probably have a better approach in mind. Notes from that PR:~

> The problem turns out to be an issue with `FasterImage` and how it was modified in https://github.com/ampproject/amp-wp/pull/1150 to allow extracting pixel dimensions from SVG images. The problem is that it is attempting to read 1024 bytes of data from the image, but the [above SVG](https://s.w.org/images/core/emoji/11/svg/1f642.svg) is only 525 bytes long. This results in a `WillWashburn\Stream\StreamBufferTooSmallException` exception being thrown, and the image size failing to be obtained, and thus the fallback image size is being used (which is obviously too big).

# Todo

- [x] Add tests.
- [x] Address issue with reading tiny SVG images.