### PR TITLE
Add fallback support for when cURL multi is not available

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,4 +30,5 @@ jobs:
 
       # run tests with phpunit
       - run: ./vendor/bin/phpunit
-      - run: ./vendor/bin/php-coveralls --coverage_clover="clover.xml"      
+      - run: DISABLE_CURL_MULTI=1 ./vendor/bin/phpunit
+      - run: ./vendor/bin/php-coveralls --coverage_clover="clover.xml"

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "willwashburn/stream": ">=1.0"
   },
   "require-dev": {
-    "mockery/mockery": "~0.9",
-    "phpunit/phpunit": "~4.0"
+    "phpunit/phpunit": "~6.0",
+    "php-mock/php-mock-phpunit": "^2.3"
   },
   "autoload": {
     "classmap": ["src"]

--- a/src/FasterImage/FasterImage.php
+++ b/src/FasterImage/FasterImage.php
@@ -68,6 +68,17 @@ class FasterImage
      */
     public function batch(array $urls)
     {
+
+        /**
+         * It turns out that even when cURL is installed, the `curl_multi_init()
+         * function may be disabled on some hosts who are seeking to guard against
+         * DDoS attacks.
+         *
+         * @see https://github.com/ampproject/amp-wp/pull/2183#issuecomment-491506514.
+         *
+         * If it is disabled, we will batch these synchronously (with a significant
+         * performance hit).
+         */
         $has_curl_multi = (
             function_exists( 'curl_multi_init' )
             &&

--- a/src/FasterImage/FasterImage.php
+++ b/src/FasterImage/FasterImage.php
@@ -61,10 +61,10 @@ class FasterImage
     /**
      * Get the size of each of the urls in a list
      *
-     * @param array $urls
+     * @param string[] $urls URLs to fetch.
      *
-     * @return array
-     * @throws \Exception
+     * @return array Results.
+     * @throws \Exception When the cURL write callback fails to amend the $results.
      */
     public function batch(array $urls)
     {
@@ -142,10 +142,10 @@ class FasterImage
     /**
      * Get the size of each of the urls in a list, using synchronous method
      *
-     * @param array $urls
+     * @param string[] $urls URLs to fetch.
      *
-     * @return array
-     * @throws \Exception
+     * @return array Results.
+     * @throws \Exception When the cURL write callback fails to amend the $results.
      */
     protected function batchSynchronously(array $urls) {
         $results = [];

--- a/src/FasterImage/FasterImage.php
+++ b/src/FasterImage/FasterImage.php
@@ -74,7 +74,7 @@ class FasterImage
          * function may be disabled on some hosts who are seeking to guard against
          * DDoS attacks.
          *
-         * @see https://github.com/ampproject/amp-wp/pull/2183#issuecomment-491506514.
+         * @see https://github.com/ampproject/amp-wp/pull/2183#issuecomment-491506514
          *
          * If it is disabled, we will batch these synchronously (with a significant
          * performance hit).
@@ -92,7 +92,6 @@ class FasterImage
             &&
             defined( 'CURLM_CALL_MULTI_PERFORM' )
         );
-        $has_curl_multi = false; // TEMP for unit testing.
         if ( ! $has_curl_multi ) {
             return $this->batchSynchronously($urls);
         }

--- a/tests/FasterImageTest.php
+++ b/tests/FasterImageTest.php
@@ -7,6 +7,29 @@ include('../vendor/autoload.php');
  */
 class FasterImageTest extends \PHPUnit\Framework\TestCase
 {
+    use \phpmock\phpunit\PHPMock;
+
+    /**
+     * Set up.
+     */
+    protected function setUp() {
+        parent::setUp();
+
+        // Mock function_exists() to return false for all curl_multi_* functions when PHPUnit is invoked with DISABLE_CURL_MULTI=1 environment variable.
+        if ( isset( $_ENV['DISABLE_CURL_MULTI'] ) && true === filter_var( $_ENV['DISABLE_CURL_MULTI'], FILTER_VALIDATE_BOOLEAN ) ) {
+            $function_exists = $this->getFunctionMock('FasterImage', 'function_exists');
+            $function_exists->expects($this->atLeastOnce())->willReturnCallback(
+                function($function) {
+                    if ( is_string($function) && 0 === strpos( $function, 'curl_multi_' ) ) {
+                        return false;
+                    } else {
+                        return function_exists($function);
+                    }
+                }
+            );
+        }
+    }
+
     /**
      * @throws Exception
      */

--- a/tests/FasterImageTest.php
+++ b/tests/FasterImageTest.php
@@ -5,7 +5,7 @@ include('../vendor/autoload.php');
 /**
  * Class FasterImageTest
  */
-class FasterImageTest extends PHPUnit_Framework_TestCase
+class FasterImageTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @throws Exception


### PR DESCRIPTION
Fixes #16.

> It turns out that even when cURL is installed, the `curl_multi_init()` function may be disabled on some hosts who are seeking to guard against DDoS attacks. See https://github.com/ampproject/amp-wp/pull/2183#issuecomment-491506514. 

This PR modifies `FasterImage::batch()` to check if cURL multi is available, and if not, it falls back to doing plain `curl_init()` calls to obtain the images sequentially.