### PR TITLE
Retry: Add fallback support for when cURL multi is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+### 1.5.0 (2019-05-25)
+* Fallback support when curl_multi_init() is not available
+
 ### 1.4.0 (2019-03-07)
 * Add support for parsing dimensions from SVG images
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ FasterImage uses the curl_muli* suite to run requests in parallel. Currently sup
 
 ```composer require fasterimage/fasterimage```
 
-Alternatively, add ```"fasterimage/fasterimage": "~1.4"``` to your composer.json
+Alternatively, add ```"fasterimage/fasterimage": "~1.5"``` to your composer.json
 
 ## Changelog
 
+* v1.5.0 - Fallback support when curl_multi_init() is not available
 * v1.4.0 - Add support for parsing dimensions from SVG images
 * v1.3.0 - Add ability for user agent, buffer size, and SSL host/peer verification to be overridden
 * v1.2.1 - Limit isRotated to only check for valid orientation values

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,8 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: mkdir -p build/logs      
+      - run: mkdir -p build/logs
+      - run: composer install -n --prefer-dist
 
       - save_cache:
           key: v1-dependencies-{{ checksum "composer.json" }}

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,6 @@ jobs:
             - v1-dependencies-
 
       - run: mkdir -p build/logs      
-      - run: composer require php-coveralls/php-coveralls && composer install -n --prefer-dist
 
       - save_cache:
           key: v1-dependencies-{{ checksum "composer.json" }}

--- a/circle.yml
+++ b/circle.yml
@@ -30,4 +30,5 @@ jobs:
 
       # run tests with phpunit
       - run: ./vendor/bin/phpunit
-      - run: ./vendor/bin/php-coveralls --coverage_clover="clover.xml"      
+      - run: DISABLE_CURL_MULTI=1 ./vendor/bin/phpunit
+      - run: ./vendor/bin/php-coveralls --coverage_clover="clover.xml"

--- a/circle.yml
+++ b/circle.yml
@@ -30,5 +30,5 @@ jobs:
 
       # run tests with phpunit
       - run: ./vendor/bin/phpunit
-      - run: DISABLE_CURL_MULTI=1 ./vendor/bin/phpunit
       - run: ./vendor/bin/php-coveralls --coverage_clover="clover.xml"
+      - run: DISABLE_CURL_MULTI=1 ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "~6.0",
-    "php-mock/php-mock-phpunit": "^2.3"
+    "php-mock/php-mock-phpunit": "^2.3",
+    "php-coveralls/php-coveralls": "^2.1"
   },
   "autoload": {
     "classmap": ["src"]

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     "willwashburn/stream": ">=1.0"
   },
   "require-dev": {
-    "mockery/mockery": "~0.9",
-    "phpunit/phpunit": "~4.0"
+    "phpunit/phpunit": "~6.0",
+    "php-mock/php-mock-phpunit": "^2.3"
   },
   "autoload": {
     "classmap": ["src"]

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,9 @@
     {
       "name": "Will Washburn",
       "email": "will@tailwindapp.com"
+    },
+    {
+      "name": "Weston Ruter",
     }
   ],
   "keywords": [

--- a/src/FasterImage/FasterImage.php
+++ b/src/FasterImage/FasterImage.php
@@ -68,6 +68,17 @@ class FasterImage
      */
     public function batch(array $urls)
     {
+
+        /**
+         * It turns out that even when cURL is installed, the `curl_multi_init()
+         * function may be disabled on some hosts who are seeking to guard against
+         * DDoS attacks.
+         *
+         * @see https://github.com/ampproject/amp-wp/pull/2183#issuecomment-491506514.
+         *
+         * If it is disabled, we will batch these synchronously (with a significant
+         * performance hit).
+         */
         $has_curl_multi = (
             function_exists( 'curl_multi_init' )
             &&

--- a/src/FasterImage/FasterImage.php
+++ b/src/FasterImage/FasterImage.php
@@ -74,7 +74,7 @@ class FasterImage
          * function may be disabled on some hosts who are seeking to guard against
          * DDoS attacks.
          *
-         * @see https://github.com/ampproject/amp-wp/pull/2183#issuecomment-491506514.
+         * @see https://github.com/ampproject/amp-wp/pull/2183#issuecomment-491506514
          *
          * If it is disabled, we will batch these synchronously (with a significant
          * performance hit).
@@ -92,7 +92,6 @@ class FasterImage
             &&
             defined( 'CURLM_CALL_MULTI_PERFORM' )
         );
-        $has_curl_multi = false; // TEMP for unit testing.
         if ( ! $has_curl_multi ) {
             return $this->batchSynchronously($urls);
         }

--- a/src/FasterImage/FasterImage.php
+++ b/src/FasterImage/FasterImage.php
@@ -68,7 +68,7 @@ class FasterImage
      */
     public function batch(array $urls)
     {
-
+        // @codeCoverageIgnoreStart
         /**
          * It turns out that even when cURL is installed, the `curl_multi_init()
          * function may be disabled on some hosts who are seeking to guard against
@@ -95,6 +95,7 @@ class FasterImage
         if ( ! $has_curl_multi ) {
             return $this->batchSynchronously($urls);
         }
+        // @codeCoverageIgnoreEnd
 
         $multi   = curl_multi_init();
         $results = array();
@@ -146,6 +147,7 @@ class FasterImage
      *
      * @return array Results.
      * @throws \Exception When the cURL write callback fails to amend the $results.
+     * @codeCoverageIgnore
      */
     protected function batchSynchronously(array $urls) {
         $results = [];

--- a/src/FasterImage/FasterImage.php
+++ b/src/FasterImage/FasterImage.php
@@ -61,13 +61,30 @@ class FasterImage
     /**
      * Get the size of each of the urls in a list
      *
-     * @param array $urls
+     * @param string[] $urls URLs to fetch.
      *
-     * @return array
-     * @throws \Exception
+     * @return array Results.
+     * @throws \Exception When the cURL write callback fails to amend the $results.
      */
     public function batch(array $urls)
     {
+        $has_curl_multi = (
+            function_exists( 'curl_multi_init' )
+            &&
+            function_exists( 'curl_multi_exec' )
+            &&
+            function_exists( 'curl_multi_add_handle' )
+            &&
+            function_exists( 'curl_multi_select' )
+            &&
+            defined( 'CURLM_OK' )
+            &&
+            defined( 'CURLM_CALL_MULTI_PERFORM' )
+        );
+        $has_curl_multi = false; // TEMP for unit testing.
+        if ( ! $has_curl_multi ) {
+            return $this->batchSynchronously($urls);
+        }
 
         $multi   = curl_multi_init();
         $results = array();
@@ -109,6 +126,33 @@ class FasterImage
             }
         }
 
+        return $results;
+    }
+
+    /**
+     * Get the size of each of the urls in a list, using synchronous method
+     *
+     * @param string[] $urls URLs to fetch.
+     *
+     * @return array Results.
+     * @throws \Exception When the cURL write callback fails to amend the $results.
+     */
+    protected function batchSynchronously(array $urls) {
+        $results = [];
+        foreach ( array_values($urls) as $count => $uri ) {
+            $results[$uri] = [];
+
+            $ch = $this->handle($uri, $results[$uri]);
+
+            curl_exec($ch);
+
+            // We can't check return value because the buffer size is too small and curl_error() will always be "Failed writing body".
+            if ( empty($results[$uri]) ) {
+                throw new \Exception("Curl handle for $uri could not be executed");
+            }
+
+            curl_close($ch);
+        }
         return $results;
     }
 
@@ -271,7 +315,7 @@ class FasterImage
              */
             //
             // hey curl! this is an error. But really we just are stopping cause
-            // we already have what we wwant
+            // we already have what we want
             return -1;
         });
 

--- a/tests/FasterImageTest.php
+++ b/tests/FasterImageTest.php
@@ -7,6 +7,29 @@ include('../vendor/autoload.php');
  */
 class FasterImageTest extends \PHPUnit\Framework\TestCase
 {
+    use \phpmock\phpunit\PHPMock;
+
+    /**
+     * Set up.
+     */
+    protected function setUp() {
+        parent::setUp();
+
+        // Mock function_exists() to return false for all curl_multi_* functions when PHPUnit is invoked with DISABLE_CURL_MULTI=1 environment variable.
+        if ( isset( $_ENV['DISABLE_CURL_MULTI'] ) && true === filter_var( $_ENV['DISABLE_CURL_MULTI'], FILTER_VALIDATE_BOOLEAN ) ) {
+            $function_exists = $this->getFunctionMock('FasterImage', 'function_exists');
+            $function_exists->expects($this->atLeastOnce())->willReturnCallback(
+                function($function) {
+                    if ( is_string($function) && 0 === strpos( $function, 'curl_multi_' ) ) {
+                        return false;
+                    } else {
+                        return function_exists($function);
+                    }
+                }
+            );
+        }
+    }
+
     /**
      * @throws Exception
      */

--- a/tests/FasterImageTest.php
+++ b/tests/FasterImageTest.php
@@ -5,7 +5,7 @@ include('../vendor/autoload.php');
 /**
  * Class FasterImageTest
  */
-class FasterImageTest extends PHPUnit_Framework_TestCase
+class FasterImageTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @throws Exception


### PR DESCRIPTION
Starting a new PR from branch on origin repo. See #17.

Fixes #16.

> It turns out that even when cURL is installed, the `curl_multi_init()` function may be disabled on some hosts who are seeking to guard against DDoS attacks. See https://github.com/ampproject/amp-wp/pull/2183#issuecomment-491506514. 

This PR modifies `FasterImage::batch()` to check if cURL multi is available, and if not, it falls back to doing plain `curl_init()` calls to obtain the images sequentially.